### PR TITLE
feature/custom-config-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ Default: `""`
 Password of `nextcloud_admin_user`. It's strongy recommended to vault this with [ansible-vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html)
 Default: `""`
 
+### `nextcloud_config_template`
+Jinja2 template to use for the Nextcloud's `config.php`. To use a custom config template, you need to:
+* create a `templates/` directory at the same level as your playbook
+* create a `templates/myconfig.php.j2` file (just choose a different name from the default template)
+* in your playbook set the var `nextcloud_config_template: myconfig.php.j2`
+Default: `"config.php.j2"`
+
 ### `nextcloud_instanceid`
 Unique instanceid. Generate a random one and keep it as long as your installation is alive.
 Default: `""`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ nextcloud_php_version: "{{ php_default_version_debian | default('7.4') }}"
 nextcloud_keep_releases: "60d"
 nextcloud_admin_user: ""
 nextcloud_admin_password: ""
+nextcloud_config_template: "config.php.j2"
 
 # To generate config.php
 nextcloud_instanceid: ""

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -108,7 +108,7 @@
 
 - name: Create {{ nextcloud_shared_path }}/config.php
   template:
-    src: config.php.j2
+    src: "{{ nextcloud_config_template }}"
     dest: "{{ nextcloud_shared_path }}/config.php"
     owner: "{{ nextcloud_php_user }}"
     group: "{{ nextcloud_php_user }}"


### PR DESCRIPTION
Add option to specify a custom configuration file for Nextcloud.

* For cases where the provided 'config.php.j2' template is not
  sufficient
* Default still points to the existing template as before
* Inspiration and steps in 'README.md' are taken from https://github.com/geerlingguy/ansible-role-gitlab/pull/89