### PR TITLE
fix: hide secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,10 @@ Default:
 List of apps to install and enable.
 Default: `[]`
 
+### `nextcloud_no_log`
+Hide sensitive data during deploy.
+Default: `true`
+
 ## Working example
 
 Here is what you should have in your `playbook.yml`:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,3 +46,6 @@ nextcloud_packages:
 
 # Post configuration
 nextcloud_apps: []
+
+# Hide sensitive data during deploy
+nextcloud_no_log: true

--- a/tasks/checks.yml
+++ b/tasks/checks.yml
@@ -30,3 +30,4 @@
     - "{{ nextcloud_passwordsalt }}"
     - "{{ nextcloud_secret }}"
     - "{{ nextcloud_dbpassword }}"
+  no_log: "{{ nextcloud_no_log }}"


### PR DESCRIPTION
Do not print out passwords in clear text during the check whether they are defined and not empty.

Optionally, printing the passwords can be enabled explicitly when setting `nextcloud_no_log: false`.